### PR TITLE
feat(history): add historical bars helper & CLI command (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-tvstreamer – TradingView WebSocket client & mini-CLI
+tvstreamer - TradingView WebSocket client & mini-CLI
 ====================================================
 
 tvstreamer is a **tiny, dependency-light** helper library that lets you stream
@@ -39,7 +39,7 @@ $ tvws -s BINANCE:BTCUSDT -s NYSE:MSFT -i 1D \
 Why another TradingView client?
 -------------------------------
 
-* **One file, one purpose.** The public surface is purposefully minimal – a
+* **One file, one purpose.** The public surface is purposefully minimal - a
   single `TvWSClient` class and a matching `tvws` CLI wrapper.
 * **Zero async complexity.** The client runs synchronously and can therefore be
   dropped into a background thread or process of your choosing.
@@ -57,7 +57,7 @@ Installation
 # PyPI (recommended)
 pip install tvstreamer
 
-# From source – editable for local development
+# From source - editable for local development
 git clone https://example.com/your-fork/tvstreamer.git
 cd tvstreamer
 pip install -e .[dev]
@@ -213,7 +213,7 @@ break-down.
 
 • The **facade** re-exports only three symbols: `TvWSClient`,
   `configure_logging`, and `trace`.  Everything else is internal.
-• A **single synchronous** websocket connection suffices – no async machinery
+• A **single synchronous** websocket connection suffices - no async machinery
   required.  If you need async, run the client in a background thread or wrap
   it with `anyio.to_thread.run_sync()`.
 • The CLI keeps zero runtime dependencies when `typer` is not available thanks
@@ -243,7 +243,7 @@ into ELK, Splunk, or your data-warehouse of choice.
 License
 -------
 
-This project is licensed under the MIT License – see `LICENSE` for details.
+This project is licensed under the MIT License - see `LICENSE` for details.
 
 
 [TradingView]: https://www.tradingview.com/

--- a/README.md
+++ b/README.md
@@ -124,11 +124,15 @@ See the low-level `TvWSClient` example above for direct generator-based access t
 ### Command-line
 
 ```bash
+```bash
 # Subscribe to two symbols, show raw frames for debug purposes
-tvws -s BINANCE:ETHUSDT -s BINANCE:BTCUSDT -i 5 -d
+	tvws -s BINANCE:ETHUSDT -s BINANCE:BTCUSDT -i 5 -d
+
+# Fetch historical bars snapshot for a symbol (no live stream)
+	tvws history BINANCE:BTCUSDT 1 100
 
 # Fetch initial history (500 candles) then continue streaming
-tvws -s NYSE:MSFT -i 1D -n 500 | tee msft.jsonl
+	tvws -s NYSE:MSFT -i 1D -n 500 | tee msft.jsonl
 ```
 
 Run `tvws --help` for the full list of options.

--- a/poetry.lock
+++ b/poetry.lock
@@ -97,7 +97,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "extra == \"cli\" and platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "platform_system == \"Windows\" or sys_platform == \"win32\""}
+markers = {main = "extra == \"cli\" and platform_system == \"Windows\"", dev = "platform_system == \"Windows\" or sys_platform == \"win32\""}
 
 [[package]]
 name = "coverage"
@@ -193,7 +193,7 @@ version = "1.3.0"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["dev"]
 markers = "python_version < \"3.11\""
 files = [
     {file = "exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10"},
@@ -227,7 +227,7 @@ version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
     {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
@@ -311,7 +311,7 @@ version = "25.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
     {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
@@ -352,7 +352,7 @@ version = "1.5.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
     {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
@@ -368,7 +368,7 @@ version = "8.3.5"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820"},
     {file = "pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"},
@@ -410,7 +410,7 @@ version = "2.4.0"
 description = "pytest plugin to abort hanging tests"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["dev"]
 files = [
     {file = "pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"},
     {file = "pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a"},
@@ -535,7 +535,7 @@ files = [
     {file = "typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c"},
     {file = "typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"},
 ]
-markers = {main = "extra == \"cli\" or python_version < \"3.11\""}
+markers = {main = "extra == \"cli\""}
 
 [[package]]
 name = "websocket-client"
@@ -556,8 +556,9 @@ test = ["websockets"]
 
 [extras]
 cli = ["typer"]
+dev = []
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8,<4.0"
-content-hash = "0bc8b924e07972c579a04c5397e733a58df48efa6b0d5635715397459554b07a"
+content-hash = "03f7943fae8c507003e10ae1d02809b471ec928f3da5df09ce799d78312d7365"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,19 +23,16 @@ websocket-client = ">=0.57.0"
 typer = "^0.9.0"
 tomli = { version = "^2.0.1", python = "<3.11" }
 
-# -------------------------------------------------------------------
-# Optional dependency groups (install via `pip install tvstreamer[cli]`)
-# -------------------------------------------------------------------
-pytest-timeout = "^2.4.0"
-
 [tool.poetry.extras]
 cli = ["typer"]
+dev = ["pytest", "pytest-timeout", "anyio", "pytest-cov", "coverage"]
 
 [tool.poetry.scripts]
 tvws = "tvstreamer.cli:app"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"
+pytest-timeout = "^2.4.0"
 anyio = "^4.0.0"
 pytest-cov = "*"
 coverage = "*"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,3 +14,13 @@ def test_help_ok():
 
     assert result.exit_code == 0, result.output
     assert "Usage" in result.output or "USAGE" in result.output
+
+def test_history_help():
+    """`tvws history --help` should exit 0 and show history usage."""
+    from typer.testing import CliRunner
+
+    from tvstreamer.cli import app
+
+    result = CliRunner().invoke(app, ["history", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "Fetch historical bars" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ def test_help_ok():
     assert result.exit_code == 0, result.output
     assert "Usage" in result.output or "USAGE" in result.output
 
+
 def test_history_help():
     """`tvws history --help` should exit 0 and show history usage."""
     from typer.testing import CliRunner

--- a/tests/test_wsclient.py
+++ b/tests/test_wsclient.py
@@ -114,3 +114,24 @@ def test_handle_payload_tick_and_bar_events() -> None:
     assert evt3.volume == 5
     assert evt3.closed is True
     assert isinstance(evt3.ts, datetime)
+
+def test_fetch_history_collects_bars(monkeypatch):
+    client = TvWSClient([], n_init_bars=1)
+    # stub send to record protocol calls without side-effects
+    sent: list = []
+    monkeypatch.setattr(client, "_send", lambda func, params: sent.append((func, params)))
+    # prepare sample bars and completion marker
+    from datetime import datetime, timezone
+
+    b1 = Bar(ts=datetime(2020, 1, 1, 0, 0, tzinfo=timezone.utc), open=1.0, high=2.0,
+             low=0.5, close=1.5, volume=100.0, symbol="SYM", interval="1", closed=True)
+    b2 = Bar(ts=datetime(2020, 1, 1, 1, 0, tzinfo=timezone.utc), open=1.5, high=2.5,
+             low=1.0, close=2.0, volume=150.0, symbol="SYM", interval="1", closed=True)
+    # replace queue with controlled one
+    client._q = queue.Queue()
+    client._q.put(b1)
+    client._q.put(b2)
+    alias = Subscription("SYM", "1").key()
+    client._q.put({"type": "bar", "sub": alias, "status": "completed"})
+    result = client._fetch_history("SYM", "1", 2)
+    assert result == [b1, b2]

--- a/tests/test_wsclient.py
+++ b/tests/test_wsclient.py
@@ -115,6 +115,7 @@ def test_handle_payload_tick_and_bar_events() -> None:
     assert evt3.closed is True
     assert isinstance(evt3.ts, datetime)
 
+
 def test_fetch_history_collects_bars(monkeypatch):
     client = TvWSClient([], n_init_bars=1)
     # stub send to record protocol calls without side-effects
@@ -123,10 +124,28 @@ def test_fetch_history_collects_bars(monkeypatch):
     # prepare sample bars and completion marker
     from datetime import datetime, timezone
 
-    b1 = Bar(ts=datetime(2020, 1, 1, 0, 0, tzinfo=timezone.utc), open=1.0, high=2.0,
-             low=0.5, close=1.5, volume=100.0, symbol="SYM", interval="1", closed=True)
-    b2 = Bar(ts=datetime(2020, 1, 1, 1, 0, tzinfo=timezone.utc), open=1.5, high=2.5,
-             low=1.0, close=2.0, volume=150.0, symbol="SYM", interval="1", closed=True)
+    b1 = Bar(
+        ts=datetime(2020, 1, 1, 0, 0, tzinfo=timezone.utc),
+        open=1.0,
+        high=2.0,
+        low=0.5,
+        close=1.5,
+        volume=100.0,
+        symbol="SYM",
+        interval="1",
+        closed=True,
+    )
+    b2 = Bar(
+        ts=datetime(2020, 1, 1, 1, 0, tzinfo=timezone.utc),
+        open=1.5,
+        high=2.5,
+        low=1.0,
+        close=2.0,
+        volume=150.0,
+        symbol="SYM",
+        interval="1",
+        closed=True,
+    )
     # replace queue with controlled one
     client._q = queue.Queue()
     client._q.put(b1)

--- a/tvstreamer/__init__.py
+++ b/tvstreamer/__init__.py
@@ -23,8 +23,7 @@ symbols are the supported public interface:
 # tvstreamer public surface – *streaming only*
 # ---------------------------------------------------------------------------
 
-# This package has been slimmed down to focus exclusively on real-time
-# WebSocket streaming.  All historical-data helpers have been removed.
+# This package supports both real-time WebSocket streaming and historical data retrieval.
 
 # Import standard library dependencies first (PEP8 / Ruff I001 compliant)
 import logging as _logging

--- a/tvstreamer/cli.py
+++ b/tvstreamer/cli.py
@@ -124,6 +124,20 @@ else:  # Typer import succeeded ------------------------------------------------
 
         _run_stream(symbol, interval, init_bars, debug)
 
+    @app.command(no_args_is_help=True)
+    def history(
+        symbol: str = typer.Argument(..., help="TradingView symbol (exchange:SYMBOL)"),
+        interval: str = typer.Argument(..., help="Resolution code (e.g. 1, 1H, 1D)"),
+        n_bars: int = typer.Argument(..., help="Number of historical bars to fetch"),
+        debug: bool = typer.Option(
+            False, "-d", "--debug", help="Print raw websocket frames for troubleshooting."
+        ),
+    ) -> None:
+        """Fetch historical bars for a symbol/interval and emit JSON lines."""
+        client = tvstreamer.TvWSClient([(symbol, interval)], ws_debug=debug)
+        for bar in client.get_history(symbol, interval, n_bars):
+            print(json.dumps(bar, default=str), flush=True)
+
     # --------------------------------------------------------------------
     # Console-script entry-points
     # --------------------------------------------------------------------

--- a/tvstreamer/cli.py
+++ b/tvstreamer/cli.py
@@ -134,9 +134,10 @@ else:  # Typer import succeeded ------------------------------------------------
         ),
     ) -> None:
         """Fetch historical bars for a symbol/interval and emit JSON lines."""
-        client = tvstreamer.TvWSClient([(symbol, interval)], ws_debug=debug)
-        for bar in client.get_history(symbol, interval, n_bars):
-            print(json.dumps(bar, default=str), flush=True)
+        # Ensure WebSocket is closed on completion or error
+        with tvstreamer.TvWSClient([(symbol, interval)], ws_debug=debug) as client:
+            for bar in client.get_history(symbol, interval, n_bars):
+                print(json.dumps(bar, default=str), flush=True)
 
     # --------------------------------------------------------------------
     # Console-script entry-points

--- a/tvstreamer/wsclient.py
+++ b/tvstreamer/wsclient.py
@@ -20,6 +20,7 @@ import queue
 import random
 import re
 import string
+import time
 import threading
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -440,13 +441,25 @@ class TvWSClient:
         # else: ignore others (ping, etc.)
 
     def _fetch_history(self, symbol: str, interval: str, n_bars: int) -> list[Bar]:
-        """Private helper: send history_get (via create_series) and collect bars until completed."""
+        """Internal: send history_get frames, collect up to n_bars, and wait for completion.
+
+        Raises:
+            TimeoutError: if no completion event arrives within timeout.
+        """
+        logger = logging.getLogger(__name__)
         sub = Subscription(symbol, interval)
         alias = sub.key()
         series_id = f"s{random.randint(1_000, 9_999)}"
         self._series[series_id] = sub
 
         sym_up = symbol.upper()
+        logger.debug(
+            "Requesting %d history bars for %s %s",
+            n_bars,
+            symbol,
+            interval,
+            extra={"code_path": __file__},
+        )
         # resolve and subscribe for history bars
         self._send("quote_add_symbols", [self._quote_session, sym_up])
         desc = f'{{"symbol":"{sym_up}","adjustment":"splits"}}'
@@ -465,9 +478,24 @@ class TvWSClient:
         )
 
         bars: list[Bar] = []
-        # collect until history completed marker
-        while True:
-            evt = self._q.get()
+        completed = False
+        deadline = time.monotonic() + max(5.0, 0.1 * n_bars)
+        while not completed and len(bars) < n_bars:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                # clean up series mapping
+                self._series.pop(series_id, None)
+                logger.warning(
+                    "Timeout fetching history for %s %s",
+                    symbol,
+                    interval,
+                    extra={"code_path": __file__},
+                )
+                raise TimeoutError(f"History fetch timeout for {symbol}:{interval}")
+            try:
+                evt = self._q.get(timeout=remaining)
+            except queue.Empty:
+                continue
             if isinstance(evt, Bar) and evt.symbol == symbol and evt.interval == interval:
                 bars.append(evt)
             elif (
@@ -476,17 +504,43 @@ class TvWSClient:
                 and evt.get("sub") == alias
                 and evt.get("status") == "completed"
             ):
-                break
+                completed = True
+
+        # clean up series mapping
+        self._series.pop(series_id, None)
+        logger.debug(
+            "Fetched %d history bars for %s %s",
+            len(bars),
+            symbol,
+            interval,
+            extra={"code_path": __file__},
+        )
         return bars
 
     def get_history(self, symbol: str, interval: str, n_bars: int) -> list[Bar]:
-        """Public: fetch historical bars synchronously (connects if needed)."""
+        """
+        Fetch historical bars synchronously (with its own queue to isolate from live stream).
+
+        Args:
+            symbol: TradingView symbol (exchange:SYMBOL).
+            interval: Resolution code (e.g. '1', '1D').
+            n_bars: Number of bars to fetch.
+
+        Returns:
+            List[Bar]: Historical bars collected.
+
+        Raises:
+            TimeoutError: If no completion event is received in time.
+        """
         own_conn = False
         if self._ws is None:
             self.connect()
             own_conn = True
+        old_q = self._q
+        self._q = queue.Queue()
         try:
             return self._fetch_history(symbol, interval, n_bars)
         finally:
+            self._q = old_q
             if own_conn:
                 self.close()


### PR DESCRIPTION
feat(history): add historical bars helper & CLI command (#21)

This PR implements issue #21, adding support for fetching historical OHLCV bars.

- Introduce `_fetch_history()` internal helper to send `create_series` frames and collect bar events until a `series_completed` marker.
- Expose public method `get_history(symbol, interval, n_bars)` that manages connect/close and returns a `list[Bar]`.
- Add new CLI subcommand `tvws history SYMBOL INTERVAL N_BARS` to output JSON lines of historical bars.
- Update README and package doc comments to document historical data support.
- Add unit tests covering `_fetch_history()` logic and CLI help for `history`.

All tests pass, type checks, lint, and formatting are green.
