### PR TITLE
Increase pytest timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,5 +78,5 @@ ignore = ["E501", "E402", "F401", "I001"]
 # -------------------------------------------------------------------
 
 [tool.pytest.ini_options]
-timeout = 5
+timeout = 10
 timeout_method = "thread"


### PR DESCRIPTION
## Summary
- increase the `pytest-timeout` default limit to 10s to prevent spurious failures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b113aa9d4832d958b6be429abf379