### PR TITLE
Add matrix CI and mypy step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,11 @@ on:
     branches: ["main"]
 
 jobs:
-  style-check:
+  test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -16,16 +19,16 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
         run: |
           python -m pip install --upgrade pip
           pip install "poetry>=1.8,<2"
 
-      - name: Install dependencies (incl. dev)
+      - name: Install dependencies
         run: |
-          poetry install --no-interaction --no-root --with dev
+          poetry install --no-interaction --all-extras
 
       - name: Black – check formatting
         run: |
@@ -37,4 +40,8 @@ jobs:
 
       - name: Mypy – static type analysis
         run: |
-          poetry run mypy .
+          poetry run mypy --strict tvstreamer
+
+      - name: Run tests
+        run: |
+          poetry run pytest -q

--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ Development
 * Run the test-suite: `pytest -q`.
 * Apply the pre-commit hooks before pushing: `pre-commit run -a`.
 
+The GitHub Actions workflow tests against Python 3.9–3.11 and runs
+`mypy --strict` alongside the unit tests.
+
 Pull requests must ship unit tests for new features and keep `ruff`/`black`
 clean.
 


### PR DESCRIPTION
## Summary
- run workflow on Python 3.9–3.11
- install extras with Poetry and run mypy strict
- document the new workflow in README

## Testing
- `black --check .`
- `ruff check .`
- `mypy --strict tvstreamer`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b211b9b54832da33cda676fa2f959