### PR TITLE
feat(models): add Candle dataclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
  - Initial changelog scaffold following Keep-a-Changelog guidelines.
  - Continuous integration now caches Poetry by lock hash, runs `pip-audit`,
    and uploads coverage to Codecov.
+ - `Candle` dataclass converting TradingView frames into typed OHLCV bars.
 
 ## [0.1.1] - 2025-07-07
 

--- a/examples/demo_stream.py
+++ b/examples/demo_stream.py
@@ -7,9 +7,7 @@ from tvstreamer.events import Tick, Bar
 
 def handle_tick(event: Tick) -> None:
     """Print tick events to the console."""
-    print(
-        f"[Tick] {event.symbol} @ {event.ts} - price={event.price}, volume={event.volume}"
-    )
+    print(f"[Tick] {event.symbol} @ {event.ts} - price={event.price}, volume={event.volume}")
 
 
 def handle_bar(event: Bar) -> None:

--- a/tests/test_candle.py
+++ b/tests/test_candle.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timezone, timedelta
+from decimal import Decimal
+
+from tvstreamer.models import Candle
+
+
+def test_from_frame_with_bar_close_time() -> None:
+    epoch = 1_600_000_000
+    frame = {
+        "n": "SYM",
+        "v": [epoch, 1.0, 2.0, 0.5, 1.5, 100.0],
+        "lbs": {"bar_close_time": epoch + 60},
+    }
+    c = Candle.from_frame(frame, interval="1m")
+    assert c.symbol == "SYM"
+    assert c.ts_open == datetime.fromtimestamp(epoch, tz=timezone.utc)
+    assert c.ts_close == datetime.fromtimestamp(epoch + 60, tz=timezone.utc)
+    assert c.open == Decimal("1.0")
+    assert c.high == Decimal("2.0")
+    assert c.low == Decimal("0.5")
+    assert c.close == Decimal("1.5")
+    assert c.volume == 100.0
+    assert c.interval == "1m"
+
+
+def test_from_frame_without_bar_close_time() -> None:
+    epoch = 1_600_000_000
+    frame = {"symbol": "SYM", "v": [epoch, 1, 2, 0, 1, 50]}
+    c = Candle.from_frame(frame, interval="5m")
+    assert c.ts_close - c.ts_open == timedelta(minutes=5)

--- a/tests/test_candle.py
+++ b/tests/test_candle.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timezone, timedelta
 from decimal import Decimal
 
+import pytest
+
 from tvstreamer.models import Candle
 
 
@@ -28,3 +30,28 @@ def test_from_frame_without_bar_close_time() -> None:
     frame = {"symbol": "SYM", "v": [epoch, 1, 2, 0, 1, 50]}
     c = Candle.from_frame(frame, interval="5m")
     assert c.ts_close - c.ts_open == timedelta(minutes=5)
+
+
+def test_from_frame_defaults_interval() -> None:
+    epoch = 1_600_000_000
+    frame = {"v": [epoch, 1, 1, 1, 1]}
+    c = Candle.from_frame(frame)
+    assert c.interval == "1m"
+    assert c.ts_close - c.ts_open == timedelta(minutes=1)
+
+
+def test_from_frame_uppercase_interval() -> None:
+    epoch = 1_600_000_000
+    frame = {"v": [epoch, 1, 1, 1, 1]}
+    c = Candle.from_frame(frame, interval="15M")
+    assert c.ts_close - c.ts_open == timedelta(minutes=15)
+
+
+def test_from_frame_error_missing_v() -> None:
+    with pytest.raises(ValueError):
+        Candle.from_frame({}, interval="1m")
+
+
+def test_from_frame_error_short_v() -> None:
+    with pytest.raises(ValueError):
+        Candle.from_frame({"v": [1, 2, 3]}, interval="1m")

--- a/tvstreamer/models.py
+++ b/tvstreamer/models.py
@@ -23,7 +23,7 @@ class Candle:
     interval: str = "1m"
 
     @classmethod
-    def from_frame(cls, frame: Mapping[str, Any], *, interval: str) -> "Candle":
+    def from_frame(cls, frame: Mapping[str, Any], *, interval: str = "1m") -> "Candle":
         """Return a :class:`Candle` built from a TradingView frame."""
         data = frame.get("v")
         if not isinstance(data, list) or len(data) < 5:
@@ -49,7 +49,7 @@ class Candle:
         if close_ts_val is not None:
             ts_close = datetime.fromtimestamp(int(close_ts_val), tz=timezone.utc)
         else:
-            ts_close = ts_open + _interval_to_timedelta(interval)
+            ts_close = ts_open + cls._interval_to_timedelta(interval)
 
         symbol = str(frame.get("n") or frame.get("symbol") or "")
         return cls(
@@ -64,14 +64,14 @@ class Candle:
             interval=interval,
         )
 
-
-def _interval_to_timedelta(interval: str) -> timedelta:
-    """Translate interval string to :class:`timedelta`."""
-    s = interval.lower()
-    if s.isdigit():
-        return timedelta(minutes=int(s))
-    units = {"m": "minutes", "h": "hours", "d": "days", "w": "weeks"}
-    for key, attr in units.items():
-        if s.endswith(key) and s[:-1].isdigit():
-            return timedelta(**{attr: int(s[:-1])})
-    raise ValueError(f"unsupported interval: {interval}")
+    @staticmethod
+    def _interval_to_timedelta(interval: str) -> timedelta:
+        """Translate interval string to :class:`timedelta`."""
+        s = interval.lower()
+        if s.isdigit():
+            return timedelta(minutes=int(s))
+        units = {"m": "minutes", "h": "hours", "d": "days", "w": "weeks"}
+        for key, attr in units.items():
+            if s.endswith(key) and s[:-1].isdigit():
+                return timedelta(**{attr: int(s[:-1])})
+        raise ValueError(f"unsupported interval: {interval}")

--- a/tvstreamer/models.py
+++ b/tvstreamer/models.py
@@ -8,7 +8,7 @@ from typing import Any, Mapping
 __all__ = ["Candle"]
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True)
 class Candle:
     """OHLCV bar with open/close timestamps."""
 

--- a/tvstreamer/models.py
+++ b/tvstreamer/models.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Any, Mapping
+
+__all__ = ["Candle"]
+
+
+@dataclass(frozen=True, slots=True)
+class Candle:
+    """OHLCV bar with open/close timestamps."""
+
+    symbol: str
+    ts_open: datetime
+    ts_close: datetime
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+    volume: float | None = None
+    interval: str = "1m"
+
+    @classmethod
+    def from_frame(cls, frame: Mapping[str, Any], *, interval: str) -> "Candle":
+        """Return a :class:`Candle` built from a TradingView frame."""
+        data = frame.get("v")
+        if not isinstance(data, list) or len(data) < 5:
+            raise ValueError("invalid candle frame")
+
+        ts_raw = data[0]
+        ts_epoch = ts_raw / 1000 if ts_raw > 1e12 else ts_raw
+        ts_open = datetime.fromtimestamp(ts_epoch, tz=timezone.utc)
+
+        def to_dec(val: Any) -> Decimal:
+            return Decimal(str(val))
+
+        open_ = to_dec(data[1])
+        high = to_dec(data[2])
+        low = to_dec(data[3])
+        close = to_dec(data[4])
+        volume = float(data[5]) if len(data) > 5 else None
+
+        lbs = frame.get("lbs")
+        close_ts_val = None
+        if isinstance(lbs, Mapping):
+            close_ts_val = lbs.get("bar_close_time")
+        if close_ts_val is not None:
+            ts_close = datetime.fromtimestamp(int(close_ts_val), tz=timezone.utc)
+        else:
+            ts_close = ts_open + _interval_to_timedelta(interval)
+
+        symbol = str(frame.get("n") or frame.get("symbol") or "")
+        return cls(
+            symbol=symbol,
+            ts_open=ts_open,
+            ts_close=ts_close,
+            open=open_,
+            high=high,
+            low=low,
+            close=close,
+            volume=volume,
+            interval=interval,
+        )
+
+
+def _interval_to_timedelta(interval: str) -> timedelta:
+    """Translate interval string to :class:`timedelta`."""
+    s = interval.lower()
+    if s.isdigit():
+        return timedelta(minutes=int(s))
+    units = {"m": "minutes", "h": "hours", "d": "days", "w": "weeks"}
+    for key, attr in units.items():
+        if s.endswith(key) and s[:-1].isdigit():
+            return timedelta(**{attr: int(s[:-1])})
+    raise ValueError(f"unsupported interval: {interval}")


### PR DESCRIPTION
## Summary
- add new `Candle` dataclass to encapsulate OHLCV bars
- helper `from_frame()` converts TradingView frames into Candle objects
- unit tests for Candle conversions
- document new model in changelog

## Testing
- `ruff check tvstreamer`
- `black --check tvstreamer`
- `mypy tvstreamer`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c76a7fd7c832d845ee02cdeef6c96