### PR TITLE
Add candle frame decoder

### DIFF
--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -3,7 +3,7 @@ import json
 
 import pytest
 
-from tvstreamer.decoder import decode_tick_frame, decode_candle_frame
+from tvstreamer.decoder import decode_tick_frame, decode_candle_frame, CandleFrame
 
 
 def test_decode_tick_frame() -> None:
@@ -25,17 +25,37 @@ def test_decode_tick_frame() -> None:
     [
         (
             '~m~208~m~{"m":"du","p":["cs_x",{"s1":{"s":[{"i":1,"v":[1600000000,1,2,0.5,1.5,100]}],"ns":{},"t":"s1","lbs":{"bar_close_time":1600000060}}}]}',
-            {"v": [1600000000, 1.0, 2.0, 0.5, 1.5, 100.0], "lbs": {"bar_close_time": 1600000060}},
+            {
+                "ts": 1_600_000_000.0,
+                "o": 1.0,
+                "h": 2.0,
+                "l": 0.5,
+                "c": 1.5,
+                "v": 100.0,
+                "bar_close_time": 1_600_000_060,
+            },
         ),
         (
             '~m~207~m~{"m":"du","p":["cs_x",{"s1":{"s":[{"i":1,"v":[1600000000,1,2,0.5,1.5,100]}],"ns":{},"t":"s1"}}]}',
-            {"v": [1600000000, 1.0, 2.0, 0.5, 1.5, 100.0]},
+            {
+                "ts": 1_600_000_000.0,
+                "o": 1.0,
+                "h": 2.0,
+                "l": 0.5,
+                "c": 1.5,
+                "v": 100.0,
+            },
         ),
     ],
 )
-def test_decode_candle_frame(raw: str, expected: dict) -> None:
+def test_decode_candle_frame(raw: str, expected: CandleFrame) -> None:
     assert decode_candle_frame(raw) == expected
 
 
 def test_decode_candle_frame_non_candle() -> None:
     assert decode_candle_frame('{"m":"qsd"}') is None
+
+
+def test_decode_candle_frame_missing_volume() -> None:
+    raw = '~m~195~m~{"m":"du","p":["cs_x",{"s1":{"s":[{"i":1,"v":[1600000000,1,2,0.5,1.5]}],"ns":{},"t":"s1"}}]}'
+    assert decode_candle_frame(raw) is None

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -1,0 +1,41 @@
+from datetime import datetime, timezone
+import json
+
+import pytest
+
+from tvstreamer.decoder import decode_tick_frame, decode_candle_frame
+
+
+def test_decode_tick_frame() -> None:
+    ts_ms = 1_600_000_000_000
+    payload = {
+        "m": "qsd",
+        "p": ["qs_x", {"n": "SYM", "v": {"lp": 1.23, "volume": 4.56, "upd": ts_ms}}],
+    }
+    raw = f"~m~{len(json.dumps(payload))}~m~" + json.dumps(payload)
+    result = decode_tick_frame(raw)
+    assert result is not None
+    assert result["price"] == pytest.approx(1.23)
+    assert result["volume"] == pytest.approx(4.56)
+    assert result["ts"] == datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (
+            '~m~208~m~{"m":"du","p":["cs_x",{"s1":{"s":[{"i":1,"v":[1600000000,1,2,0.5,1.5,100]}],"ns":{},"t":"s1","lbs":{"bar_close_time":1600000060}}}]}',
+            {"v": [1600000000, 1.0, 2.0, 0.5, 1.5, 100.0], "lbs": {"bar_close_time": 1600000060}},
+        ),
+        (
+            '~m~207~m~{"m":"du","p":["cs_x",{"s1":{"s":[{"i":1,"v":[1600000000,1,2,0.5,1.5,100]}],"ns":{},"t":"s1"}}]}',
+            {"v": [1600000000, 1.0, 2.0, 0.5, 1.5, 100.0]},
+        ),
+    ],
+)
+def test_decode_candle_frame(raw: str, expected: dict) -> None:
+    assert decode_candle_frame(raw) == expected
+
+
+def test_decode_candle_frame_non_candle() -> None:
+    assert decode_candle_frame('{"m":"qsd"}') is None

--- a/tvstreamer/decoder.py
+++ b/tvstreamer/decoder.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Optional
+
+__all__ = ["decode_tick_frame", "decode_candle_frame"]
+
+# Regex for tick frames with last price (lp), volume and update timestamp
+_re_tick = re.compile(
+    r"qsd.*?\"lp\"\s*:\s*(?P<price>[0-9.]+).*?\"volume\"\s*:\s*(?P<vol>[0-9.]+).*?\"upd\"\s*:\s*(?P<ts>\d+)"
+)
+
+# Regex for candle frames (TradingView 'du' updates). Captures OHLCV and optional bar_close_time
+_re_candle = re.compile(
+    r"\"m\":\"du\".*?\"v\":\[(?P<ts>[0-9.]+),(?P<open>[0-9.]+),(?P<high>[0-9.]+),(?P<low>[0-9.]+),(?P<close>[0-9.]+),(?P<vol>[0-9.]+)\](?:.*?\"bar_close_time\":(?P<bct>\d+))?"
+)
+
+
+def decode_tick_frame(raw: str) -> Optional[dict]:
+    """Return a simple dict from a TradingView tick frame or ``None``."""
+    m = _re_tick.search(raw)
+    if not m:
+        return None
+    ts = datetime.fromtimestamp(int(m.group("ts")) / 1000, tz=timezone.utc)
+    return {
+        "ts": ts,
+        "price": float(m.group("price")),
+        "volume": float(m.group("vol")),
+    }
+
+
+def decode_candle_frame(raw: str) -> Optional[dict]:
+    """Return a dict with candle values from a TradingView ``du`` frame."""
+    m = _re_candle.search(raw)
+    if not m:
+        return None
+
+    ts_val = float(m.group("ts"))
+    frame = {
+        "v": [
+            ts_val,
+            float(m.group("open")),
+            float(m.group("high")),
+            float(m.group("low")),
+            float(m.group("close")),
+            float(m.group("vol")),
+        ]
+    }
+    bct = m.group("bct")
+    if bct:
+        frame["lbs"] = {"bar_close_time": int(bct)}
+    return frame

--- a/tvstreamer/decoder.py
+++ b/tvstreamer/decoder.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Optional, TypedDict
 
 __all__ = ["decode_tick_frame", "decode_candle_frame"]
 
@@ -12,9 +12,19 @@ _re_tick = re.compile(
 )
 
 # Regex for candle frames (TradingView 'du' updates). Captures OHLCV and optional bar_close_time
-_re_candle = re.compile(
+_CANDLE_RE = re.compile(
     r"\"m\":\"du\".*?\"v\":\[(?P<ts>[0-9.]+),(?P<open>[0-9.]+),(?P<high>[0-9.]+),(?P<low>[0-9.]+),(?P<close>[0-9.]+),(?P<vol>[0-9.]+)\](?:.*?\"bar_close_time\":(?P<bct>\d+))?"
 )
+
+
+class CandleFrame(TypedDict, total=False):
+    ts: float
+    o: float
+    h: float
+    l: float  # noqa: E741 - field mirrors TradingView key
+    c: float
+    v: float
+    bar_close_time: int
 
 
 def decode_tick_frame(raw: str) -> Optional[dict]:
@@ -30,24 +40,27 @@ def decode_tick_frame(raw: str) -> Optional[dict]:
     }
 
 
-def decode_candle_frame(raw: str) -> Optional[dict]:
-    """Return a dict with candle values from a TradingView ``du`` frame."""
-    m = _re_candle.search(raw)
+def decode_candle_frame(raw: str) -> Optional[CandleFrame]:
+    """Return OHLCV values from a TradingView ``du`` frame.
+
+    Example
+    -------
+    >>> decode_candle_frame('~m~207~m~{"m":"du","p":["s",{"s1":{"s":[{"i":1,"v":[1,2,3,4,5,6]}],"t":"s1"}}]}')
+    {'ts': 1.0, 'o': 2.0, 'h': 3.0, 'l': 4.0, 'c': 5.0, 'v': 6.0}
+    """
+    m = _CANDLE_RE.search(raw)
     if not m:
         return None
 
-    ts_val = float(m.group("ts"))
-    frame = {
-        "v": [
-            ts_val,
-            float(m.group("open")),
-            float(m.group("high")),
-            float(m.group("low")),
-            float(m.group("close")),
-            float(m.group("vol")),
-        ]
+    frame: CandleFrame = {
+        "ts": float(m.group("ts")),
+        "o": float(m.group("open")),
+        "h": float(m.group("high")),
+        "l": float(m.group("low")),
+        "c": float(m.group("close")),
+        "v": float(m.group("vol")),
     }
     bct = m.group("bct")
     if bct:
-        frame["lbs"] = {"bar_close_time": int(bct)}
+        frame["bar_close_time"] = int(bct)
     return frame


### PR DESCRIPTION
## Summary
- implement a decoder module with tick & candle frame support
- add unit tests covering candle frame decoding

## Testing
- `ruff check tvstreamer tests`
- `black --check tvstreamer tests/test_decoder.py`
- `mypy tvstreamer`
- `PYTHONPATH=. pytest -q`
- `PYTHONPATH=. pytest --cov=tvstreamer --cov-report=term -q`

------
https://chatgpt.com/codex/tasks/task_e_686c7b859798832d9affe84a85d08764