### PR TITLE
Add CandleStream pub-sub with tests

### DIFF
--- a/tests/test_streamer.py
+++ b/tests/test_streamer.py
@@ -1,0 +1,65 @@
+from datetime import datetime, timezone
+
+try:
+    from anyio.testing import MockClock
+except Exception:  # pragma: no cover - older anyio
+    from trio.testing import MockClock
+
+import trio
+import anyio
+
+from tvstreamer.streamer import CandleStream
+from tvstreamer.hub import CandleHub
+from tvstreamer.models import Candle
+
+
+class DummyConn:
+    def __init__(self, frames: list[str]):
+        self._frames = list(frames)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._frames:
+            raise StopAsyncIteration
+        await anyio.sleep(0)
+        return self._frames.pop(0)
+
+    async def send(self, msg: str) -> None:
+        pass
+
+
+def test_candlestream_integration():
+    frames = [
+        '~m~208~m~{"m":"du","p":["cs_x",{"s1":{"s":[{"i":1,"v":[1600000000,1,2,0.5,1.5,100]}],"ns":{},"t":"s1","lbs":{"bar_close_time":1600000060}}}]}',
+        '~m~207~m~{"m":"du","p":["cs_x",{"s1":{"s":[{"i":1,"v":[1600000000,1,2,0.5,1.5,100]}],"ns":{},"t":"s1"}}]}',
+        '~m~207~m~{"m":"du","p":["cs_x",{"s1":{"s":[{"i":1,"v":[1600000060,1,2,0.5,1.6,100]}],"ns":{},"t":"s1"}}]}',
+    ]
+
+    def connect():
+        return DummyConn(frames.copy())
+
+    hub = CandleHub(maxsize=10)
+    out: list[Candle] = []
+
+    async def main() -> None:
+        async with CandleStream(connect, [("SYM", "1m")], hub=hub) as stream:
+            it = stream.subscribe()
+            for _ in range(3):
+                out.append(await it.__anext__())
+            await it.aclose()
+            stream._tg.cancel_scope.cancel()
+
+    trio.run(main, clock=MockClock())
+
+    assert len(out) == 3
+    assert all(isinstance(c, Candle) for c in out)
+    assert out[0].symbol == "SYM"
+    assert out[0].ts_open.tzinfo is timezone.utc

--- a/tvstreamer/__init__.py
+++ b/tvstreamer/__init__.py
@@ -46,6 +46,7 @@ from .wsclient import TvWSClient
 from .streaming import StreamRouter
 from .connection import TradingViewConnection
 from .hub import CandleHub
+from .streamer import CandleStream
 
 # Public re-exports -----------------------------------------------------------
 
@@ -54,6 +55,7 @@ __all__ = [
     "StreamRouter",
     "TradingViewConnection",
     "CandleHub",
+    "CandleStream",
     "configure_logging",
     "trace",
 ]

--- a/tvstreamer/streamer.py
+++ b/tvstreamer/streamer.py
@@ -1,0 +1,95 @@
+"""Async candle streaming via :class:`CandleHub`."""
+
+from __future__ import annotations
+
+import anyio
+import logging
+from typing import AsyncIterator, Callable, Iterable, AsyncContextManager
+
+from .connection import TradingViewConnection
+from .decoder import decode_candle_frame
+from .hub import CandleHub
+from .models import Candle
+
+__all__ = ["CandleStream"]
+
+logger = logging.getLogger(__name__)
+
+
+class CandleStream:
+    """Stream candle updates and fan-out via :class:`CandleHub`."""
+
+    def __init__(
+        self,
+        connect: Callable[[], AsyncContextManager],
+        pairs: Iterable[tuple[str, str]],
+        *,
+        hub: CandleHub | None = None,
+        reconnect_delay: float = 1.0,
+    ) -> None:
+        self._connect = connect
+        self._pairs = list(pairs)
+        self.hub = hub or CandleHub()
+        self._delay = reconnect_delay
+        self._tg: anyio.abc.TaskGroup | None = None
+
+    async def __aenter__(self) -> "CandleStream":
+        self._tg = anyio.create_task_group()
+        await self._tg.__aenter__()
+        self._tg.start_soon(self._run)
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        assert self._tg is not None
+        self._tg.cancel_scope.cancel()
+        await self._tg.__aexit__(exc_type, exc, tb)
+        await self.hub.aclose()
+
+    async def _run(self) -> None:
+        assert self._tg is not None
+        while True:
+            try:
+                async with self._connect() as ws:
+                    conn = TradingViewConnection(sender=ws.send)  # type: ignore[attr-defined]
+                    for sym, interval in self._pairs:
+                        await conn.subscribe_candles(sym, interval)
+                    async for raw in ws:
+                        frame = decode_candle_frame(raw)
+                        if not frame:
+                            continue
+                        sym, interval = self._pairs[0]
+                        payload = {
+                            "n": sym,
+                            "v": [
+                                frame["ts"],
+                                frame["o"],
+                                frame["h"],
+                                frame["l"],
+                                frame["c"],
+                                frame["v"],
+                            ],
+                        }
+                        bct = frame.get("bar_close_time")
+                        if bct is not None:
+                            payload["lbs"] = {"bar_close_time": bct}
+                        candle = Candle.from_frame(payload, interval=interval)
+                        await self.hub.publish(candle)
+            except anyio.get_cancelled_exc_class():
+                break
+            except Exception:  # pragma: no cover - reconnect branch
+                logger.exception("candle stream error", extra={"code_path": __name__})
+                await anyio.sleep(self._delay)
+
+    def subscribe(self) -> AsyncIterator[Candle]:
+        """Return an async iterator of :class:`Candle` events."""
+
+        recv = self.hub.subscribe()
+
+        async def _iterator() -> AsyncIterator[Candle]:
+            try:
+                while True:
+                    yield await recv.receive()
+            finally:
+                await recv.aclose()
+
+        return _iterator()


### PR DESCRIPTION
## Summary
- add `CandleStream` async streamer that fan-outs candles to `CandleHub`
- export `CandleStream` from the public API
- integration test exercises candle streaming through the hub

## Testing
- `ruff check tvstreamer`
- `black --check tvstreamer`
- `mypy tvstreamer`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c8b511af0832d8a0d1c6a349ce12c