### PR TITLE
feat(history): async historic candle fetch

### DIFF
--- a/tests/test_historic_ws.py
+++ b/tests/test_historic_ws.py
@@ -1,0 +1,184 @@
+try:
+    from anyio.testing import MockClock
+except Exception:  # pragma: no cover - older anyio
+    from trio.testing import MockClock
+
+import trio
+import anyio
+import logging
+
+import tvstreamer.historic as historic
+from tvstreamer.models import Candle
+
+
+class DummyWS:
+    def __init__(self, frames):
+        self._frames = list(frames)
+        self.sent = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._frames:
+            raise StopAsyncIteration
+        await anyio.sleep(0)
+        return self._frames.pop(0)
+
+    async def send(self, msg: str) -> None:
+        self.sent.append(msg)
+
+
+def make_frames(n: int) -> list[str]:
+    base = 1_600_000_000
+    frames = []
+    for i in range(n):
+        ts = base + i * 60
+        payload = {
+            "m": "du",
+            "p": [
+                "cs_x",
+                {
+                    "s1": {
+                        "s": [{"i": 1, "v": [ts, 1, 2, 0.5, 1.5, 100]}],
+                        "ns": {},
+                        "t": "s1",
+                        "lbs": {"bar_close_time": ts + 60},
+                    }
+                },
+            ],
+        }
+        raw = historic._tv_msg("du", payload["p"])
+        frames.append(raw)
+    complete = historic._tv_msg("series_completed", ["cs_x", "s1"])
+    frames.append(complete)
+    return frames
+
+
+def run_fetch(monkeypatch, limit: int, frames: list[str]):
+    ws = DummyWS(frames)
+
+    class DummyConnect:
+        def __init__(self, ws):
+            self.ws = ws
+
+        def __await__(self):
+            async def _wrap():
+                return self.ws
+
+            return _wrap().__await__()
+
+        async def __aenter__(self):
+            return self.ws
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    def connect(*_a, **_kw):
+        return DummyConnect(ws)
+
+    monkeypatch.setattr(historic.websockets, "connect", connect)
+
+    async def main():
+        return await historic.get_historic_candles("SYM", "1", limit, timeout=1)
+
+    return trio.run(main, clock=MockClock())
+
+
+def test_basic_limits(monkeypatch):
+    frames = make_frames(4)
+    res = run_fetch(monkeypatch, 3, frames.copy())
+    assert len(res) == 3
+    assert all(isinstance(c, Candle) for c in res)
+
+    res2 = run_fetch(monkeypatch, 4, frames.copy())
+    assert len(res2) == 4
+
+    res3 = run_fetch(monkeypatch, 10, frames.copy())
+    assert len(res3) == 4
+
+
+def test_timeout(monkeypatch, caplog):
+    caplog.set_level(logging.WARNING)
+
+    class StalledWS(DummyWS):
+        async def __anext__(self):
+            await anyio.sleep(1)
+            raise StopAsyncIteration
+
+    ws = StalledWS([])
+
+    class DummyConnect:
+        def __init__(self, ws):
+            self.ws = ws
+
+        def __await__(self):
+            async def _wrap():
+                return self.ws
+
+            return _wrap().__await__()
+
+        async def __aenter__(self):
+            return self.ws
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    def connect(*_a, **_kw):
+        return DummyConnect(ws)
+
+    monkeypatch.setattr(historic.websockets, "connect", connect)
+
+    async def main():
+        return await historic.get_historic_candles("SYM", "1", 2, timeout=0.1)
+
+    result = trio.run(main, clock=MockClock())
+    assert result == []
+    assert any("Timeout" in r.message for r in caplog.records)
+
+
+def test_cache(monkeypatch):
+    frames = make_frames(2)
+    ws = DummyWS(frames)
+    calls = 0
+
+    class DummyConnect:
+        def __init__(self, ws):
+            self.ws = ws
+
+        def __await__(self):
+            async def _wrap():
+                return self.ws
+
+            return _wrap().__await__()
+
+        async def __aenter__(self):
+            return self.ws
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    def connect(*_a, **_kw):
+        nonlocal calls
+        calls += 1
+        return DummyConnect(ws)
+
+    monkeypatch.setattr(historic.websockets, "connect", connect)
+    monkeypatch.setattr(historic.time, "monotonic", lambda: 1000)
+
+    async def main1():
+        return await historic.get_historic_candles("SYM", "1", 2, timeout=1)
+
+    async def main2():
+        return await historic.get_historic_candles("SYM", "1", 2, timeout=1)
+
+    res1 = trio.run(main1, clock=MockClock())
+    res2 = trio.run(main2, clock=MockClock())
+    assert calls == 1
+    assert res1 == res2

--- a/tvstreamer/__init__.py
+++ b/tvstreamer/__init__.py
@@ -47,6 +47,7 @@ from .streaming import StreamRouter
 from .connection import TradingViewConnection
 from .hub import CandleHub
 from .streamer import CandleStream
+from .historic import get_historic_candles
 
 # Public re-exports -----------------------------------------------------------
 
@@ -56,6 +57,7 @@ __all__ = [
     "TradingViewConnection",
     "CandleHub",
     "CandleStream",
+    "get_historic_candles",
     "configure_logging",
     "trace",
 ]

--- a/tvstreamer/__init__.py
+++ b/tvstreamer/__init__.py
@@ -47,7 +47,7 @@ from .streaming import StreamRouter
 from .connection import TradingViewConnection
 from .hub import CandleHub
 from .streamer import CandleStream
-from .historic import get_historic_candles
+from .historic import get_historic_candles, TooManyRequestsError
 
 # Public re-exports -----------------------------------------------------------
 
@@ -58,6 +58,7 @@ __all__ = [
     "CandleHub",
     "CandleStream",
     "get_historic_candles",
+    "TooManyRequestsError",
     "configure_logging",
     "trace",
 ]

--- a/tvstreamer/historic.py
+++ b/tvstreamer/historic.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import random
+import string
+import time
+from functools import lru_cache
+
+import anyio
+import websockets
+
+from .decoder import decode_candle_frame
+from .models import Candle
+
+__all__ = ["get_historic_candles", "TooManyRequestsError"]
+
+
+class TooManyRequestsError(RuntimeError):
+    """Raised when concurrent history sessions exceed the allowed limit."""
+
+
+# global semaphore controlling concurrent websocket sessions
+_websocket_semaphore = asyncio.Semaphore(3)
+
+_WS_ENDPOINT = "wss://data.tradingview.com/socket.io/websocket"
+
+
+def _tv_msg(method: str, params: list) -> str:
+    payload = json.dumps({"m": method, "p": params}, separators=(",", ":"))
+    return f"~m~{len(payload)}~m~" + payload
+
+
+async def _fetch_history(symbol: str, interval: str, limit: int, timeout: float) -> list[Candle]:
+    symbol_up = symbol.upper()
+    chart = "cs_" + "".join(random.choice(string.ascii_lowercase) for _ in range(12))
+    quote = "qs_" + "".join(random.choice(string.ascii_lowercase) for _ in range(12))
+    candles: list[Candle] = []
+    completed = False
+    logger = logging.getLogger(__name__)
+
+    try:
+        async with websockets.connect(_WS_ENDPOINT) as ws:
+            await ws.send(_tv_msg("set_auth_token", ["unauthorized_user_token"]))
+            await ws.send(_tv_msg("chart_create_session", [chart]))
+            await ws.send(_tv_msg("quote_create_session", [quote]))
+            await ws.send(_tv_msg("quote_set_fields", [quote, "lp", "volume", "ch"]))
+            await ws.send(_tv_msg("quote_add_symbols", [quote, symbol_up]))
+            await ws.send(
+                _tv_msg(
+                    "quote_add_series",
+                    [quote, symbol_up, interval, {"countback": limit}],
+                )
+            )
+
+            with anyio.move_on_after(timeout) as cancel:
+                async for raw in ws:
+                    if "series_completed" in raw or "quote_completed" in raw:
+                        completed = True
+                        break
+                    frame = decode_candle_frame(raw)
+                    if not frame or "bar_close_time" not in frame:
+                        continue
+                    payload = {
+                        "symbol": symbol_up,
+                        "v": [
+                            frame["ts"],
+                            frame["o"],
+                            frame["h"],
+                            frame["l"],
+                            frame["c"],
+                            frame["v"],
+                        ],
+                        "lbs": {"bar_close_time": frame["bar_close_time"]},
+                    }
+                    candles.append(Candle.from_frame(payload, interval=interval))
+                    if len(candles) >= limit:
+                        completed = True
+                        break
+            if cancel.cancel_called:
+                logger.warning(
+                    "Timeout fetching history for %s %s",
+                    symbol,
+                    interval,
+                    extra={"code_path": __file__},
+                )
+    except Exception as exc:
+        logger.warning(
+            "Error fetching history for %s %s: %s",
+            symbol,
+            interval,
+            exc,
+            extra={"code_path": __file__},
+        )
+        return []
+
+    if not completed:
+        logger.warning(
+            "Incomplete history for %s %s", symbol, interval, extra={"code_path": __file__}
+        )
+    return candles[-limit:]
+
+
+@lru_cache(maxsize=128)
+def _cached_fetch(symbol: str, interval: str, limit: int, timeout: float, ttl: int) -> list[Candle]:
+    return asyncio.run(_fetch_history(symbol, interval, limit, timeout))
+
+
+async def get_historic_candles(
+    symbol: str, interval: str, limit: int = 500, *, timeout: float = 10.0
+) -> list[Candle]:
+    """Return recent closed candles for ``symbol`` and ``interval``.
+
+    Example
+    -------
+    >>> await get_historic_candles("BINANCE:BTCUSDT", "1m", limit=200)
+    """
+
+    sem = _websocket_semaphore
+    if sem.locked():
+        raise TooManyRequestsError
+    await sem.acquire()
+
+    try:
+        ttl = int(time.monotonic() // 60)
+        return await anyio.to_thread.run_sync(_cached_fetch, symbol, interval, limit, timeout, ttl)
+    finally:
+        sem.release()


### PR DESCRIPTION
## Summary
- implement `get_historic_candles` to fetch bars asynchronously
- expose the helper via package exports
- add extensive websocket-based history tests

## Testing
- `ruff check tvstreamer tests/test_historic_ws.py`
- `black --check tvstreamer`
- `mypy --config-file mypy.ini tvstreamer`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cee463bf4832d97306c9de6ad9cfb