### PR TITLE
Add candle streaming CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,16 @@ anyio.run(main)
 	tvws -s BINANCE:ETHUSDT -s BINANCE:BTCUSDT -i 5 -d
 
 # Fetch historical bars snapshot for a symbol (no live stream)
-	tvws history BINANCE:BTCUSDT 1 100
+        tvws history BINANCE:BTCUSDT 1 100
 
 # Fetch initial history (500 candles) then continue streaming
-	tvws -s NYSE:MSFT -i 1D -n 500 | tee msft.jsonl
+        tvws -s NYSE:MSFT -i 1D -n 500 | tee msft.jsonl
+
+# Stream BTC/USDT 5‑minute candle closes
+        tvws candles live --symbol BINANCE:BTCUSDT --interval 5m
+
+# Fetch last 100 NVDA hourly candles as a table
+        tvws candles hist --symbol NASDAQ:NVDA --interval 1h --limit 100
 ```
 
 Run `tvws --help` for the full list of options.

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ anyio.run(main)
 
 # Fetch last 100 NVDA hourly candles as a table
         tvws candles hist --symbol NASDAQ:NVDA --interval 1h --limit 100
+        # install 'rich' for coloured table output
 ```
 
 Run `tvws --help` for the full list of options.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -79,6 +79,7 @@ Future Extensions
 
 * Async wrapper around `TvWSClient` for trio/anyio projects.
 * Pluggable back-pressure handling (ring buffers, bounded queues).
+* `tvws candles` implements live & historic candle helpers.
 * Richer CLI sub-commands (snapshot, export CSV, replay streams).
 
 This document should evolve alongside the code-base.  If you touch more than a

--- a/tests/test_cli_candles.py
+++ b/tests/test_cli_candles.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import tvstreamer
+from tvstreamer.cli import app
+from tvstreamer.models import Candle
+
+
+class DummyStream:
+    def __init__(self, candles: list[Candle]) -> None:
+        self._candles = candles
+
+    async def __aenter__(self) -> "DummyStream":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        pass
+
+    def subscribe(self):
+        async def _iter():
+            for c in self._candles:
+                yield c
+
+        return _iter()
+
+
+def test_candles_live(monkeypatch):
+    from typer.testing import CliRunner
+    import types
+    import sys
+
+    sample = [
+        Candle(
+            symbol="BTCUSD",
+            ts_open=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            ts_close=datetime(2020, 1, 1, 0, 5, tzinfo=timezone.utc),
+            open=Decimal("1"),
+            high=Decimal("2"),
+            low=Decimal("0.5"),
+            close=Decimal("1.5"),
+            volume=1,
+            interval="5m",
+        )
+    ]
+
+    class _Factory:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __call__(self, *a, **kw):
+            return DummyStream(sample)
+
+    monkeypatch.setattr(tvstreamer, "CandleStream", lambda *a, **kw: DummyStream(sample))
+    monkeypatch.setitem(
+        sys.modules, "websockets", types.SimpleNamespace(connect=lambda *a, **k: None)
+    )
+
+    res = CliRunner().invoke(app, ["candles", "live", "--symbol", "BTCUSD", "--interval", "5m"])
+    assert res.exit_code == 0
+    assert "1.5" in res.output
+
+
+def test_candles_hist(monkeypatch):
+    from typer.testing import CliRunner
+
+    sample = [
+        Candle(
+            symbol="NVDA",
+            ts_open=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            ts_close=datetime(2020, 1, 1, 1, tzinfo=timezone.utc),
+            open=Decimal("1"),
+            high=Decimal("2"),
+            low=Decimal("0.5"),
+            close=Decimal("1.5"),
+            volume=1,
+            interval="1h",
+        )
+    ]
+
+    async def fake_get(symbol: str, interval: str, limit: int = 500, *, timeout: float = 10.0):
+        return sample
+
+    monkeypatch.setattr(tvstreamer, "get_historic_candles", fake_get)
+
+    res = CliRunner().invoke(
+        app,
+        ["candles", "hist", "--symbol", "NVDA", "--interval", "1h", "--limit", "1"],
+    )
+    assert res.exit_code == 0
+    assert "NVDA" in res.output
+    assert "1.5" in res.output

--- a/tests/test_cli_candles.py
+++ b/tests/test_cli_candles.py
@@ -57,7 +57,11 @@ def test_candles_live(monkeypatch):
         sys.modules, "websockets", types.SimpleNamespace(connect=lambda *a, **k: None)
     )
 
-    res = CliRunner().invoke(app, ["candles", "live", "--symbol", "BTCUSD", "--interval", "5m"])
+    res = CliRunner().invoke(
+        app,
+        ["candles", "live", "--symbol", "BTCUSD", "--interval", "5m"],
+        env={"COLUMNS": "120"},
+    )
     assert res.exit_code == 0
     assert "1.5" in res.output
 
@@ -87,6 +91,7 @@ def test_candles_hist(monkeypatch):
     res = CliRunner().invoke(
         app,
         ["candles", "hist", "--symbol", "NVDA", "--interval", "1h", "--limit", "1"],
+        env={"COLUMNS": "120"},
     )
     assert res.exit_code == 0
     assert "NVDA" in res.output


### PR DESCRIPTION
## Summary
- add `candles` Typer group with `live` and `hist` subcommands
- support global `--debug` and `--quiet` flags
- document new commands in README and architecture notes
- test candle CLI behaviour

## Testing
- `ruff check tvstreamer`
- `black --check tvstreamer`
- `mypy tvstreamer`
- `pytest -q tests/test_cli_candles.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686cf7913bf4832d9334a6b358f07140