### PR TITLE
Update docs for candle features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ The project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-07-08
+
 ### Added
- - Initial changelog scaffold following Keep-a-Changelog guidelines.
- - Continuous integration now caches Poetry by lock hash, runs `pip-audit`,
-   and uploads coverage to Codecov.
- - `Candle` dataclass converting TradingView frames into typed OHLCV bars.
+- Initial changelog scaffold following Keep-a-Changelog guidelines.
+- Continuous integration now caches Poetry by lock hash, runs `pip-audit`,
+  and uploads coverage to Codecov.
+- `Candle` dataclass converting TradingView frames into typed OHLCV bars.
+- `CandleHub` in-process pub/sub helper and `CandleStream` for async
+  broadcasting.
+- `get_historic_candles` helper with caching to avoid redundant requests.
+- `tvws candles` subcommands for live streaming and historic downloads.
 
 ## [0.1.1] - 2025-07-07
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,26 @@ with TvWSClient(subs, n_init_bars=500) as client:
             handle_bar(event)
 ```
 
+#### Candle utilities
+
+```python
+import anyio
+import websockets
+from tvstreamer import CandleStream, get_historic_candles
+
+async def live() -> None:
+    async with CandleStream(websockets.connect, [("BINANCE:BTCUSDT", "5m")]) as cs:
+        async for c in cs.subscribe():
+            print(c.close)
+
+async def hist() -> None:
+    data = await get_historic_candles("BINANCE:BTCUSDT", "1h", limit=100)
+    print(data[-1].close)
+
+anyio.run(live)
+anyio.run(hist)
+```
+
 ### CLI quick demo
 
 ```bash

--- a/docs/candles.md
+++ b/docs/candles.md
@@ -1,0 +1,40 @@
+# Live and historic candles
+
+The library offers high-level helpers around candle data so you don't
+have to decode TradingView frames yourself.
+
+## API overview
+
+- `CandleHub` – lightweight pub/sub queue for forwarding events to many
+  consumers.
+- `CandleStream` – async wrapper that connects to TradingView and
+  publishes `Candle` objects through a hub.
+- `get_historic_candles(symbol, interval, limit=500, *, timeout=10.0)` –
+  fetch a list of closed candles. Results are cached for 60 seconds and
+  no more than three concurrent sessions are opened.
+
+## Intervals
+
+TradingView accepts the following resolution codes:
+
+```
+1, 3, 5, 15, 30, 60, 120, 240, D, W, M
+```
+
+Aliases such as `5m`, `1h`, `1d` and `1w` are also recognised.
+
+## Performance tips
+
+- Reuse a single `CandleStream` for multiple consumers by sharing its
+  hub.
+- Historical fetches hit an in-memory cache; avoid spamming the API in a
+  tight loop.
+- The stream automatically reconnects with exponential backoff if the
+  websocket drops.
+
+### CLI examples
+
+```bash
+$ tvws candles live --symbol BINANCE:BTCUSDT --interval 5m
+$ tvws candles hist --symbol BINANCE:BTCUSDT --interval 1h --limit 100
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# tvstreamer documentation
+
+See the [README](../README.md) for installation and a general overview.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,6 @@
+site_name: tvstreamer
+nav:
+  - Home: index.md
+  - Architecture: ARCHITECTURE.md
+  - Candles: candles.md
+docs_dir: docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "tvstreamer"
 # is populated at runtime via `importlib.metadata.version()` to avoid keeping
 # multiple copies in sync.
 # Keep semantic version starting at 0.1.x while project is in early development
-version = "0.1.1"
+version = "0.2.0"
 # Stream live & historical market data from TradingView’s undocumented
 # WebSocket API.
 description = "TradingView WebSocket integration & historical data downloader"

--- a/tvstreamer/cli.py
+++ b/tvstreamer/cli.py
@@ -241,7 +241,7 @@ else:  # Typer import succeeded ------------------------------------------------
                         )
             except (KeyboardInterrupt, anyio.get_cancelled_exc_class()):
                 msg = "Stream interrupted"
-                if Console:
+                if Console is not None:
                     Console().print(f"[yellow]{msg}[/]")
                 else:
                     print(msg, file=sys.stderr)
@@ -261,7 +261,7 @@ else:  # Typer import succeeded ------------------------------------------------
 
         candles_data = anyio.run(_fetch)
 
-        if Table and Console:
+        if Table is not None and Console is not None:
             table = Table(title=f"{symbol} {interval}")
             table.add_column("Time")
             table.add_column("Open", justify="right")


### PR DESCRIPTION
## Summary
- document candle utilities via new docs/candles.md
- add Quick Start snippet for CandleStream and history helper
- set up mkdocs configuration
- bump to v0.2.0 and update changelog
- fix optional rich check for mypy

## Testing
- `mkdocs build -q`
- `mkdocs serve --dev-addr localhost:8001 --quiet` *(interrupted)*
- `pytest -q`
- `mypy --config-file mypy.ini tvstreamer`
- `ruff check tvstreamer`
- `black --check tvstreamer`

------
https://chatgpt.com/codex/tasks/task_e_686d0794034c832da0be8bd857b10afb