### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file following th
 The project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+ - CLI now installs required websockets; candle & socket commands no longer crash.
+ - tvws stream/history emit valid JSON objects instead of stringified dataclasses.
+### Improved
+ - Unsupported interval values raise a concise CLI error (status 2).
 
 ## [0.2.0] - 2025-07-08
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ Installation
 pip install tvstreamer
 pip install tvstreamer[cli]
 
+# Candle streaming commands require the optional `websockets` dependency
+# installed via the `[cli]` extra:
+#
+#     pip install tvstreamer[cli]
+
 # From source - editable for local development
 git clone https://example.com/your-fork/tvstreamer.git
 cd tvstreamer
@@ -216,6 +221,9 @@ anyio.run(main)
         tvws candles hist --symbol NASDAQ:NVDA --interval 1h --limit 100
         # install 'rich' for coloured table output
 ```
+
+`tvws stream` and `tvws history` output line-delimited JSON for easy piping into
+scripts or tools like `jq`.
 
 Run `tvws --help` for the full list of options.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "tvstreamer"
 # is populated at runtime via `importlib.metadata.version()` to avoid keeping
 # multiple copies in sync.
 # Keep semantic version starting at 0.1.x while project is in early development
-version = "0.2.0"
+version = "0.3.1"
 # Stream live & historical market data from TradingView’s undocumented
 # WebSocket API.
 description = "TradingView WebSocket integration & historical data downloader"
@@ -36,9 +36,10 @@ python = ">=3.8,<4.0"
 websocket-client = ">=0.57.0"
 typer = "^0.9.0"
 tomli = { version = "^2.0.1", python = "<3.11" }
+websockets = "^12.0"
 
 [tool.poetry.extras]
-cli = ["typer"]
+cli = ["typer", "websockets"]
 dev = ["pytest", "pytest-timeout", "anyio", "pytest-cov", "coverage"]
 
 [tool.poetry.scripts]

--- a/tests/test_cli_happy.py
+++ b/tests/test_cli_happy.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from typer.testing import CliRunner
+
+import tvstreamer
+from tvstreamer.cli import app
+from tvstreamer.events import Tick, Bar
+
+
+class DummyClient:
+    def __init__(self, *a: Any, **kw: Any) -> None:
+        pass
+
+    def __enter__(self) -> "DummyClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        pass
+
+    def stream(self):
+        yield Tick(datetime(2020, 1, 1, tzinfo=timezone.utc), 1.0, 1.0, "BTCUSDT")
+
+    def get_history(self, symbol: str, interval: str, n_bars: int):
+        return [
+            Bar(
+                ts=datetime(2020, 1, 1, tzinfo=timezone.utc),
+                open=1,
+                high=2,
+                low=0.5,
+                close=1.5,
+                volume=1,
+                symbol=symbol,
+                interval=interval,
+                closed=True,
+            )
+        ]
+
+
+def test_stream_json(monkeypatch):
+    monkeypatch.setattr(tvstreamer, "TvWSClient", DummyClient)
+    res = CliRunner().invoke(app, ["stream", "-s", "BINANCE:BTCUSDT", "-n", "1"])
+    assert res.exit_code == 0
+    first = res.stdout.splitlines()[0]
+    assert json.loads(first)["symbol"] == "BTCUSDT"
+
+
+def test_history_json(monkeypatch):
+    monkeypatch.setattr(tvstreamer, "TvWSClient", DummyClient)
+    res = CliRunner().invoke(app, ["history", "BINANCE:BTCUSDT", "1", "1"])
+    assert res.exit_code == 0
+    first = res.stdout.splitlines()[0]
+    assert json.loads(first)["symbol"] == "BINANCE:BTCUSDT"

--- a/tests/test_cli_validation.py
+++ b/tests/test_cli_validation.py
@@ -1,0 +1,10 @@
+from typer.testing import CliRunner
+import typer
+
+from tvstreamer.cli import app
+
+
+def test_invalid_interval():
+    res = CliRunner().invoke(app, ["stream", "-s", "SYM", "--interval", "2m"])
+    assert res.exit_code == 2
+    assert "Invalid value for '-i' / '--interval'" in res.stderr

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+import typer
 
 try:
     from anyio.testing import MockClock
@@ -59,5 +60,5 @@ def test_invalid_interval(monkeypatch):
 
     import trio
 
-    with pytest.raises(ValueError):
+    with pytest.raises(typer.BadParameter):
         trio.run(main, clock=MockClock())

--- a/tests/test_missing_websockets.py
+++ b/tests/test_missing_websockets.py
@@ -1,0 +1,18 @@
+from typer.testing import CliRunner
+import sys
+
+from tvstreamer.cli import app
+
+
+def test_missing_websockets(monkeypatch):
+    monkeypatch.setitem(sys.modules, "websockets", None)
+    import tvstreamer.historic as hist
+
+    monkeypatch.setattr(hist, "websockets", None)
+    res = CliRunner().invoke(
+        app,
+        ["candles", "hist", "--symbol", "SYM", "--interval", "1m", "--limit", "1"],
+    )
+    assert res.exit_code == 1
+    assert "pip install tvstreamer[cli]" in res.stderr
+    assert "Traceback" not in res.stderr

--- a/tvstreamer/cli.py
+++ b/tvstreamer/cli.py
@@ -33,6 +33,7 @@ except ModuleNotFoundError:  # pragma: no cover - missing optional dep
 
 import tvstreamer
 from . import intervals
+from .json_utils import to_json
 
 # ---------------------------------------------------------------------------
 # Optional import guard – provide helpful error if Typer is absent.
@@ -110,7 +111,7 @@ else:  # Typer import succeeded ------------------------------------------------
 
         with client:
             for event in client.stream():
-                print(json.dumps(event, default=str), flush=True)
+                print(to_json(event), flush=True)
 
     def _symbol_option() -> str:
         return typer.Option(..., "--symbol", "-s", help="TradingView symbol")
@@ -181,7 +182,7 @@ else:  # Typer import succeeded ------------------------------------------------
         # Ensure WebSocket is closed on completion or error
         with tvstreamer.TvWSClient([(symbol, interval)], ws_debug=debug) as client:
             for bar in client.get_history(symbol, interval, n_bars):
-                print(json.dumps(bar, default=str), flush=True)
+                print(to_json(bar), flush=True)
 
     # --------------------------------------------------------------------
     # Candle utilities

--- a/tvstreamer/historic.py
+++ b/tvstreamer/historic.py
@@ -10,26 +10,10 @@ import string
 import time
 
 import anyio
+import typer
+from typing import Any
 
-try:  # optional heavy dependency
-    import websockets  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover - optional
-
-    class _MissingWebsockets:
-        @staticmethod
-        def connect(*_a, **_kw):
-            class _Ctx:
-                async def __aenter__(self):  # pragma: no cover - runtime failure
-                    raise ModuleNotFoundError(
-                        "websockets package is required for get_historic_candles"
-                    )
-
-                async def __aexit__(self, exc_type, exc, tb):
-                    return False
-
-            return _Ctx()
-
-    websockets = _MissingWebsockets()
+websockets: Any = None
 
 from .decoder import decode_candle_frame
 from .models import Candle
@@ -46,6 +30,22 @@ class TooManyRequestsError(RuntimeError):
 _websocket_semaphore = asyncio.Semaphore(3)
 
 _WS_ENDPOINT = "wss://data.tradingview.com/socket.io/websocket"
+
+
+async def _ensure_websockets() -> None:
+    try:
+        global websockets
+        if websockets is None:
+            import websockets as _ws  # type: ignore
+
+            websockets = _ws
+    except ModuleNotFoundError as exc:  # pragma: no cover
+        typer.secho(
+            "Command requires the 'websockets' extra.  Try: pip install tvstreamer[cli]",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(1) from exc
 
 
 def _tv_msg(method: str, params: list) -> str:
@@ -157,6 +157,7 @@ async def get_historic_candles(
     >>> await get_historic_candles("BINANCE:BTCUSDT", "1m", limit=200)
     """
 
+    await _ensure_websockets()
     res = validate(interval)
     sem = _websocket_semaphore
     if sem.locked():

--- a/tvstreamer/intervals.py
+++ b/tvstreamer/intervals.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 ``validate()`` accepts minute-based strings like ``"5m"`` or ``"15"`` as well as
 hour/day/week aliases (e.g. ``"1h"``, ``"1d"``). Sub-minute resolutions are not
-supported and will raise ``ValueError``.
+supported and will raise ``typer.BadParameter``.
 """
 
 from typing import Set
+
+import typer
 
 __all__ = ["validate", "ALLOWED_INTERVALS"]
 
@@ -43,9 +45,9 @@ def validate(raw: str) -> str:
 
     if cleaned.isdigit():
         if cleaned not in ALLOWED_INTERVALS:
-            raise ValueError(f"Unsupported interval: {raw}")
+            raise typer.BadParameter(f"Unsupported interval: {raw}")
         return cleaned
     cleaned = cleaned.upper()
     if cleaned not in ALLOWED_INTERVALS:
-        raise ValueError(f"Unsupported interval: {raw}")
+        raise typer.BadParameter(f"Unsupported interval: {raw}")
     return cleaned

--- a/tvstreamer/json_utils.py
+++ b/tvstreamer/json_utils.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import dataclasses
+import datetime
+import json
+from typing import Any
+
+
+def to_json(obj: Any) -> str:
+    """Return a JSON string ensuring dataclasses and datetimes are encoded as plain
+    objects/ISO-8601 strings.
+
+    >>> to_json(MyEvent(ts=datetime.datetime.utcnow()))
+    '{"ts": "2025-07-08T12:34:56.123456Z", "price": 123.45}'
+    """
+
+    def _encoder(o: Any) -> Any:  # noqa: D401
+        if dataclasses.is_dataclass(o):
+            return dataclasses.asdict(o)
+        if isinstance(o, datetime.datetime):
+            return o.isoformat().replace("+00:00", "Z")
+        raise TypeError(f"Object of type {type(o).__name__} is not JSON serialisable")
+
+    return json.dumps(obj, default=_encoder, separators=(",", ":"))


### PR DESCRIPTION
## Summary
- add websockets optional dependency for CLI
- emit JSON via new `to_json` helper
- improve interval validation errors
- ensure websockets extra is installed for historic candles
- document websockets extra and JSON lines
- add tests for CLI output, validation and missing websockets
- bump version to 0.3.1

## Testing
- `ruff check tvstreamer tests`
- `black --check tvstreamer tests`
- `mypy --config-file mypy.ini tvstreamer`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d1995abf8832db84b95ec597bc21a