### PR TITLE
Fix async candle subscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file following th
 
 The project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- `tvws candles live` no longer disconnects with `critical_error: quote_add_series` after TradingView protocol change (July 2025).
+
 ## [0.3.3] - 2025-07-09
 ### Fixed
 - TradingView handshake and framing corrected for candle streams.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,11 @@ All notable changes to this project will be documented in this file following th
 The project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Fixed
-- `tvws candles live` no longer disconnects with `critical_error: quote_add_series` after TradingView protocol change (July 2025).
 
 ## [0.3.3] - 2025-07-09
 ### Fixed
 - TradingView handshake and framing corrected for candle streams.
+- `tvws candles live` no longer disconnects with `critical_error: quote_add_series` after TradingView protocol change (July 2025).
 
 ## [0.3.2] - 2025-07-08
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ async def hist() -> None:
 anyio.run(live)
 anyio.run(hist)
 ```
-Under the hood the async helper negotiates a chart session and creates
+Under the hood, async helper negotiates a chart session and creates
 series subscriptions automatically.
 
 ### CLI quick demo

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ async def hist() -> None:
 anyio.run(live)
 anyio.run(hist)
 ```
-Under the hood, async helper negotiates a chart session and creates
+Under the hood, the async helper negotiates a chart session and creates
 series subscriptions automatically.
 
 ### CLI quick demo

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ async def hist() -> None:
 anyio.run(live)
 anyio.run(hist)
 ```
+Under the hood the async helper negotiates a chart session and creates
+series subscriptions automatically.
 
 ### CLI quick demo
 

--- a/docs/candles.md
+++ b/docs/candles.md
@@ -3,6 +3,9 @@
 The library offers high-level helpers around candle data so you don't
 have to decode TradingView frames yourself.
 
+`CandleStream` now establishes a chart session internally, as TradingView
+removed the old `quote_add_series` method in July 2025.
+
 ## API overview
 
 - `CandleHub` – lightweight pub/sub queue for forwarding events to many

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -51,6 +51,8 @@ async def test_handshake_and_prefix_once() -> None:
     ]
     payload = json.loads(re.split(r"~m~\d+~m~", sent[4])[1])
     assert quote_session in payload["p"]
+    # ensure obsolete method is absent
+    assert not any("quote_add_series" in m for m in sent)
 
 
 @pytest.mark.anyio

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -41,9 +41,7 @@ async def test_handshake_and_prefix_once() -> None:
     # frames are length-prefixed
     assert all(m.startswith("~m~") for m in sent)
     # first candle subscription after handshake
-    sub_methods = [
-        json.loads(re.split(r"~m~\d+~m~", m)[1])["m"] for m in sent[4:7]
-    ]
+    sub_methods = [json.loads(re.split(r"~m~\d+~m~", m)[1])["m"] for m in sent[4:7]]
     assert sub_methods == [
         "quote_add_symbols",
         "resolve_symbol",

--- a/tvstreamer/cli.py
+++ b/tvstreamer/cli.py
@@ -207,7 +207,10 @@ else:  # Typer import succeeded ------------------------------------------------
     # Candle utilities
     # --------------------------------------------------------------------
 
-    candles = typer.Typer(no_args_is_help=True, help="Live and historic candles")
+    candles = typer.Typer(
+        no_args_is_help=True,
+        help="Live and historic candles via TradingView chart sessions",
+    )
     app.add_typer(candles, name="candles")
 
     @candles.command("live", no_args_is_help=True)
@@ -215,7 +218,7 @@ else:  # Typer import succeeded ------------------------------------------------
         symbol: str = _symbol_option(),
         interval: str = _interval_option(),
     ) -> None:
-        """Stream candle updates and print OHLC values."""
+        """Stream candle updates using TradingView chart sessions."""
 
         async def _run() -> None:
             try:

--- a/tvstreamer/connection.py
+++ b/tvstreamer/connection.py
@@ -25,6 +25,7 @@ class TradingViewConnection:
         self._tick_subs: Set[str] = set()
         self._candle_subs: Set[Tuple[str, str]] = set()
         self._quote_session = self._gen_quote_session()
+        self._chart_session = self._gen_chart_session()
         self._started = False
         self._token = token or "unauthorized_user_token"
         self._handshake_lock = anyio.Lock()
@@ -45,6 +46,11 @@ class TradingViewConnection:
         return f"~m~{len(payload.encode())}~m~{payload}"
 
     @staticmethod
+    def _gen_chart_session() -> str:
+        alphabet = string.ascii_lowercase
+        return "cs_" + "".join(secrets.choice(alphabet) for _ in range(12))
+
+    @staticmethod
     def _gen_quote_session() -> str:
         alphabet = string.ascii_lowercase
         return "qs_" + "".join(secrets.choice(alphabet) for _ in range(12))
@@ -54,6 +60,7 @@ class TradingViewConnection:
             if self._started:
                 return
             await self._send("set_auth_token", [self._token])
+            await self._send("chart_create_session", [self._chart_session, ""])
             await self._send("quote_create_session", [self._quote_session])
             await self._send(
                 "quote_set_fields",
@@ -83,8 +90,18 @@ class TradingViewConnection:
         await self._ensure_started()
         res = validate(interval)
         sym = symbol.upper()
+        series_id = f"s{secrets.randbelow(9000) + 1000}"
+        alias = f"{sym}_{series_id}"
+        await self._send("quote_add_symbols", [self._quote_session, sym])
+        await self._send(
+            "resolve_symbol",
+            [self._chart_session, alias, {"symbol": sym, "adjustment": "splits"}],
+        )
+        await self._send(
+            "create_series",
+            [self._chart_session, series_id, series_id, alias, res, 1, ""],
+        )
         self._candle_subs.add((sym, res))
-        await self._send("quote_add_series", [self._quote_session, sym, res])
         logging.getLogger(__name__).log(
             TRACE_LEVEL,
             "Subscribed to %s %s-bar",
@@ -101,6 +118,4 @@ class TradingViewConnection:
                 await self._send("quote_remove_symbols", [self._quote_session, sym])
             self._tick_subs.clear()
         if self._candle_subs:
-            for sym, interval in list(self._candle_subs):
-                await self._send("quote_remove_series", [self._quote_session, sym, interval])
             self._candle_subs.clear()


### PR DESCRIPTION
## Summary
- use chart sessions for async candle subscriptions
- clarify chart session usage in docs and README
- tweak candle CLI help to mention chart sessions
- update changelog and tests for new protocol

## Testing
- `ruff check tvstreamer`
- `black --check tvstreamer`
- `mypy --config-file mypy.ini tvstreamer`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dcaa3faf4832db2e11541f6367c8b